### PR TITLE
implememented __matmul__ for dot product

### DIFF
--- a/points/vectors.py
+++ b/points/vectors.py
@@ -70,6 +70,10 @@ class Vector:
         return self * other
 
 
+    def __matmul__(self, other):
+        return self.dot(other)
+
+
     def length(self):
         """Returns the length of the Vector. This is the number of values it
         contains, not its :py:meth:`magnitude`.

--- a/tests/unit/test_vectors.py
+++ b/tests/unit/test_vectors.py
@@ -252,6 +252,12 @@ class VectorDotProductTests(TestCase):
         vector2.length.return_value = 2
         self.assertEqual(vector1.dot(vector2), 66)
 
+    def test_can_get_dot_product_matmul(self):
+        vector1 = Vector(-6, 8)
+        vector2 = Mock(Vector)
+        vector2._values = [5, 12]
+        vector2.length.return_value = 2
+        self.assertEqual(vector1 @ vector2, 66)
 
     def test_dot_product_requires_vector(self):
         vector1 = Vector(-6, -8)


### PR DESCRIPTION
Hey, I added the `__matmul__` method so that the dot product between two vectors can be written as 
`C = A @ B`, which is equivalent to `C = A.dot(B)`. This has been added for Python 3.5 onwards (https://docs.python.org/3/whatsnew/3.5.html#whatsnew-pep-465)